### PR TITLE
Null check for player in TooltipHandler

### DIFF
--- a/java/squeek/spiceoflife/gui/TooltipHandler.java
+++ b/java/squeek/spiceoflife/gui/TooltipHandler.java
@@ -81,7 +81,7 @@ public class TooltipHandler
 	@SubscribeEvent
 	public void onItemTooltip(ItemTooltipEvent event)
 	{
-		if (ModConfig.FOOD_MODIFIER_ENABLED && event.getItemStack() != null && FoodHelper.isValidFood(event.getItemStack()))
+		if (ModConfig.FOOD_MODIFIER_ENABLED && event.getEntityPlayer() != null && event.getItemStack() != null && FoodHelper.isValidFood(event.getItemStack()))
 		{
 			int totalFoodEaten = FoodHistory.get(event.getEntityPlayer()).totalFoodsEatenAllTime;
 			List<String> toolTipStringsToAdd = new ArrayList<String>();


### PR DESCRIPTION
The EntityPlayer from the event is not explicitly specified as Nonnull and I've had stacktraces caused by NullPointerExceptions from "event.getEntityPlayer()" in ItemTooltipEvent handlers on occasion, so I feel like there should be a null check just in case.
